### PR TITLE
Make VPP use less CPU

### DIFF
--- a/docker/allinone/startup1.conf
+++ b/docker/allinone/startup1.conf
@@ -7,6 +7,8 @@ unix {
   cli-listen /run/vpp/cli-vpp1.sock
 
   startup-config /etc/vpp/config1.txt
+
+  poll-sleep-usec 100
 }
 
 api-trace {

--- a/docker/allinone/startup2.conf
+++ b/docker/allinone/startup2.conf
@@ -7,6 +7,8 @@ unix {
   cli-listen /run/vpp/cli-vpp2.sock
 
   startup-config /etc/vpp/config2.txt
+
+  poll-sleep-usec 100
 }
 
 api-trace {

--- a/docker/multiple/startup1.conf
+++ b/docker/multiple/startup1.conf
@@ -7,6 +7,8 @@ unix {
   cli-listen /run/vpp/cli-vpp1.sock
 
   startup-config /etc/vpp/config1.txt
+
+  poll-sleep-usec 100
 }
 
 api-trace {

--- a/docker/multiple/startup2.conf
+++ b/docker/multiple/startup2.conf
@@ -7,6 +7,8 @@ unix {
   cli-listen /run/vpp/cli-vpp2.sock
 
   startup-config /etc/vpp/config2.txt
+
+  poll-sleep-usec 100
 }
 
 api-trace {


### PR DESCRIPTION
Set `poll-sleep-usec 100` for all VPP instances.

Signed-off-by: Ian Wells <iawells@cisco.com>
Signed-off-by: Kyle Mestery <mestery@mestery.com>