### PR TITLE
Pin VPP version to 18.07.1

### DIFF
--- a/docker/base/Dockerfile.base
+++ b/docker/base/Dockerfile.base
@@ -2,5 +2,8 @@ FROM centos
 
 ARG REPO=release
 
-RUN curl -s https://packagecloud.io/install/repositories/fdio/${REPO}/script.rpm.sh |  bash
-RUN yum -y update; yum -y install sudo iproute vpp vpp-plugins vpp-api-python
+RUN curl -s https://packagecloud.io/install/repositories/fdio/${REPO}/script.rpm.sh |  bash && \
+    yum -y update && \
+    yum -y install sudo iproute vpp-18.07.1-release vpp-plugins-18.07.1-release vpp-api-python-18.07.1-release vpp-lib-18.07.1-release vpp-devel-18.07.1-release && \
+    yum clean all && \
+    rm -rf /var/cache/yum

--- a/docker/strongswan/Dockerfile.vpp
+++ b/docker/strongswan/Dockerfile.vpp
@@ -4,7 +4,9 @@ COPY startstrongswan.sh /
 COPY startvpp.sh /
 COPY startup.conf /etc/vpp/startup.conf
 
-RUN yum -y install epel-release
-RUN yum -y install strongswan tcpdump
+RUN yum -y install epel-release && \
+    yum -y install strongswan tcpdump && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 ENTRYPOINT /startvpp.sh

--- a/docker/vppvpn/Dockerfile.strongswan
+++ b/docker/vppvpn/Dockerfile.strongswan
@@ -1,6 +1,14 @@
 FROM vpp-container-fun/base
 
-RUN yum -y install epel-release tcpdump gmp-devel vpp-lib vpp-devel gperftools-devel gperftools-libs gperftools gperf
-RUN yum -y group install "Development Tools"
-RUN git clone https://github.com/mestery/strongswan.git && cd strongswan && git fetch && git checkout vpp-rebase && cd ../
-RUN cd strongswan && ./autogen.sh && ./configure --enable-libipsec --enable-socket-vpp --enable-kernel-vpp && make && make install
+RUN yum -y install epel-release tcpdump gmp-devel gperftools-devel gperftools-libs gperftools gperf && \
+    yum -y group install "Development Tools" && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
+    git clone https://github.com/mestery/strongswan.git && \
+    cd strongswan && \
+    git fetch && \
+    git checkout vpp-rebase && \
+    ./autogen.sh && \
+    ./configure --enable-libipsec --enable-socket-vpp --enable-kernel-vpp && \
+    make && \
+    make install


### PR DESCRIPTION
The latest version (18.10.0) was causing issues when building StrongSwan.

While in here, also shrink the container images down a bit and optimize
their build.

Signed-off-by: Kyle Mestery <mestery@mestery.com>