### PR TITLE
Reorganize the Makefiles to make them easier to read

### DIFF
--- a/docker/allinone/Makefile.allinone
+++ b/docker/allinone/Makefile.allinone
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_VPP_ALLINONE=vpp-container-fun/vpp-allinone
+
+.PHONY: docker-build-allinone
+docker-build-allinone: docker-build-base
+	@cd docker/allinone && ${DOCKERBUILD} -t ${DOCKER_VPP_ALLINONE} -f Dockerfile .
+
+.PHONY: run-allinone
+run-allinone:
+	@docker run --cap-add IPC_LOCK --cap-add NET_ADMIN --env-file ./docker/allinone/env.list -id --name vppallinone ${DOCKER_VPP_ALLINONE} && sleep 15
+
+.PHONY: test-allinone
+test-allinone:
+	@docker exec -it vppallinone ping -c 5 10.10.2.2

--- a/docker/base/Makefile.base
+++ b/docker/base/Makefile.base
@@ -1,0 +1,19 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_VPP_BASE=vpp-container-fun/base
+
+.PHONY: docker-build-base
+docker-build-base:
+	@cd docker/base && ${DOCKERBUILD} -t ${DOCKER_VPP_BASE} -f Dockerfile.base .

--- a/docker/multiple/Makefile.multiple
+++ b/docker/multiple/Makefile.multiple
@@ -1,0 +1,33 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_VPP_MULTIPLE1=vpp-container-fun/multiple-vpp1
+DOCKER_VPP_MULTIPLE2=vpp-container-fun/multiple-vpp2
+
+
+.PHONY: docker-build-multiple
+docker-build-multiple: docker-build-base
+	@cd docker/multiple && ${DOCKERBUILD} -t ${DOCKER_VPP_MULTIPLE1} -f Dockerfile.vpp1 .
+	@cd docker/multiple && ${DOCKERBUILD} -t ${DOCKER_VPP_MULTIPLE2} -f Dockerfile.vpp2 .
+
+.PHONY: run-multiple
+run-multiple:
+	@mkdir -p run
+	@rm -rf run/vpp*
+	@docker run -v `pwd`/run:/run --cap-add IPC_LOCK --cap-add NET_ADMIN --env-file ./docker/multiple/env.list -id --name vpp1 ${DOCKER_VPP_MULTIPLE1} && sleep 15
+	@docker run -v `pwd`/run:/run --cap-add IPC_LOCK --cap-add NET_ADMIN --env-file ./docker/multiple/env.list -id --name vpp2 ${DOCKER_VPP_MULTIPLE2} && sleep 15
+
+.PHONY: test-multiple
+test-multiple:
+	@docker exec -it vpp1 ping -c 5 10.10.2.2

--- a/docker/strongswan/Makefile.strongswan
+++ b/docker/strongswan/Makefile.strongswan
@@ -1,0 +1,27 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_STRONGSWAN_VPP=vpp-container-fun/strongswan-vpp
+
+.PHONY: docker-build-strongswan
+docker-build-strongswan: docker-build-base
+	@cd docker/strongswan && ${DOCKERBUILD} -t ${DOCKER_STRONGSWAN_VPP} -f Dockerfile.vpp .
+
+.PHONY: run-strongswan
+run-strongswan:
+	@docker run --cap-add IPC_LOCK --cap-add NET_ADMIN --env-file ./docker/strongswan/env.list -id --name strongswanvpp ${DOCKER_STRONGSWAN_VPP}
+
+.PHONY: test-strongswan
+test-strongswan:
+	@docker exec -it strongswanvpp ping 192.168.124.100 -c 5

--- a/docker/vppvpn/Makefile.vppvpn
+++ b/docker/vppvpn/Makefile.vppvpn
@@ -1,0 +1,34 @@
+# Copyright (c) 2018 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_VPPVPNBASE=vpp-container-fun/vppvpnbase
+DOCKER_VPPVPNSERVER=vpp-container-fun/vppvpnserver
+DOCKER_VPPVPNCLIENT=vpp-container-fun/vppvpnclient
+
+.PHONY: docker-build-vppvpnbase
+docker-build-vppvpnbase: docker-build-base
+	@cd docker/vppvpn && ${DOCKERBUILD} -t ${DOCKER_VPPVPNBASE} -f Dockerfile.strongswan --build-arg STRONGSWAN_REPO_URL=${BA_STRONGSWAN_REPO_URL} --build-arg STRONGSWAN_COMMIT=${BA_STRONGSWAN_COMMIT} .
+
+.PHONY: docker-build-vppvpn
+docker-build-vppvpn: docker-build-base docker-build-vppvpnbase
+	@cd docker/vppvpn && ${DOCKERBUILD} -t ${DOCKER_VPPVPNSERVER} -f Dockerfile.vpnserver .
+	@cd docker/vppvpn && ${DOCKERBUILD} -t ${DOCKER_VPPVPNCLIENT} -f Dockerfile.vpnclient .
+
+.PHONY: run-vppvpn
+run-vppvpn:
+	@cd ./docker/vppvpn && ./runme.sh ${DOCKER_VPPVPNSERVER} ${DOCKER_VPPVPNCLIENT}
+
+.PHONY: test-vppvpn
+test-vppvpn:
+	@docker exec -it vppvpnclient ping 192.168.124.100 -c 5


### PR DESCRIPTION
This moves the logic around "build/run/test" for each Dockerfile into
a per-directory Makefile.

Signed-off-by: Kyle Mestery <mestery@mestery.com>