### PR TITLE
Fix the VRPP configuration so it works correctly

### DIFF
--- a/docker/ha-scale-vpn/startstrongswan1.sh
+++ b/docker/ha-scale-vpn/startstrongswan1.sh
@@ -73,6 +73,13 @@ sudo mv /tmp/ipsec.secrets /etc/ipsec.secrets
 # Setup keepalived
 cat > /etc/keepalived/keepalived.conf << EOL
 ! Configuration File for keepalived
+
+vrrp_sync_group VG1 {
+  group {
+    VI_1
+    VI_2
+  }
+}
  
 vrrp_instance VI_1 {
   state MASTER
@@ -80,6 +87,7 @@ vrrp_instance VI_1 {
   virtual_router_id 51
   priority 150
   advert_int 1
+  nopreempt
   authentication {
     auth_type PASS
     auth_pass Vpp123
@@ -88,6 +96,7 @@ vrrp_instance VI_1 {
     ${CLUSTERIP}/22 brd 10.122.223.255 dev eth0
   }
   notify /etc/keepalived/notifyipsec.sh
+}
 
 vrrp_instance VI_2 {
   state MASTER
@@ -95,6 +104,7 @@ vrrp_instance VI_2 {
   virtual_router_id 61
   priority 150
   advert_int 1
+  nopreempt
   authentication {
     auth_type PASS
     auth_pass Vpp123
@@ -102,7 +112,6 @@ vrrp_instance VI_2 {
   virtual_ipaddress {
     ${VPNCLUSTERIP}/22 brd 10.223.223.255 dev eth1
   }
-}
 }
 EOL
 

--- a/docker/ha-scale-vpn/startstrongswan2.sh
+++ b/docker/ha-scale-vpn/startstrongswan2.sh
@@ -74,12 +74,20 @@ sudo mv /tmp/ipsec.secrets /etc/ipsec.secrets
 cat > /etc/keepalived/keepalived.conf << EOL
 ! Configuration File for keepalived
 
+vrrp_sync_group VG1 {
+  group {
+    VI_1
+    VI_2
+  }
+}
+
 vrrp_instance VI_1 {
   state BACKUP
   interface eth0
-  virtual_router_id 51
+  virtual_router_id 52
   priority 100
   advert_int 1
+  nopreempt
   authentication {
     auth_type PASS
     auth_pass Vpp123
@@ -93,9 +101,10 @@ vrrp_instance VI_1 {
 vrrp_instance VI_2 {
   state BACKUP
   interface eth1
-  virtual_router_id 61
+  virtual_router_id 62
   priority 100
   advert_int 1
+  nopreempt
   authentication {
     auth_type PASS
     auth_pass Vpp123


### PR DESCRIPTION
This ensure a few things are fixed:

* Fix incorrect curly brace placement which was causing incorrect
  keepalived configuration on the master.
* Set nopreempt mode on both master and server.
* Setup a vrrp_sync_group.
* Ensure the backup has different virtual_router_id's than the
  master nodes.

Signed-off-by: Kyle Mestery <mestery@mestery.com>