### PR TITLE
Re-enable ha-scale-testing in travis-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,8 @@ travis:
 	@echo "Files:"
 	@echo "$$(git diff --name-only $$TRAVIS_COMMIT_RANGE)"
 
-# NOTE: We do not run ha-scale-vpn by default here because it has issues in travis-ci.
-#       See #31 for more details.
 .PHONY: run
-run: run-allinone run-multiple run-strongswan run-vppvpn run-cups-vppvpn
+run: run-allinone run-multiple run-strongswan run-vppvpn run-cups-vppvpn run-ha-scale-vpn
 
-# NOTE: We do not test ha-scale-vpn by default here because it has issues in travis-ci.
-#       See #31 for more details.
 .PHONY: test
-test: test-allinone test-multiple test-strongswan test-vppvpn test-cups-vppvpn
+test: test-allinone test-multiple test-strongswan test-vppvpn test-cups-vppvpn test-ha-scale-vpn

--- a/docker/ha-scale-vpn/Makefile.ha-scale-vpn
+++ b/docker/ha-scale-vpn/Makefile.ha-scale-vpn
@@ -35,7 +35,7 @@ run-ha-scale-vpn:
 
 .PHONY: test-ha-scale-vpn
 test-ha-scale-vpn:
-	@docker exec -it ha-vpnclient ping 10.223.226.51 -c 5
+	@docker exec -it ha-vpnclient ping 10.122.223.252 -c 5
 
 .PHONY: remove-ha-scale-vpn
 remove-ha-scale-vpn:


### PR DESCRIPTION
Closes #31

Now that #33 has merged, re-enable testing ha-scale-vpn in travis-ci,
as I believe the VRRP configuration fixes should allow this to run
again.

Signed-off-by: Kyle Mestery <mestery@mestery.com>