### PR TITLE
Some fixups for the IPSEC configuration

### DIFF
--- a/docker/ha-scale-vpn/startvpnclient.sh
+++ b/docker/ha-scale-vpn/startvpnclient.sh
@@ -16,11 +16,11 @@ conn %default
 
 conn net-net
         type=tunnel
-        right=${CLUSTERIP}
-        rightsubnet=${VPN_SUBNET}/${VPN_SUBNET_MASK}
-        rightauth=psk
-        left=${CLIENT_IP}
+        left=${CLUSTERIP}
+        leftsubnet=${VPN_SUBNET}/${VPN_SUBNET_MASK}
         leftauth=psk
+        right=${CLIENT_IP}
+        rightauth=psk
         auto=add
 EOL
 sudo mv /tmp/ipsec.conf /etc/ipsec.conf


### PR DESCRIPTION
* Add in-memory address pools to share IP addresses across active-active nodes
* Correct left/right designations
* Add verbose charon logging to a separate logfile

Signed-off-by: Kyle Mestery <mestery@mestery.com>