### PR TITLE
Update the scale.sh script to work with a larger number of clients

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 sudo: required
+dist: xenial
 
 language: go
 service:


### PR DESCRIPTION
Modify the script so it iterates based on decimal values of IP
addresses. Ensure we do not use seq anymore either, as it expands
the commandline buffer too much.

Signed-off-by: Kyle Mestery <mestery@mestery.com>